### PR TITLE
Removes overflow hidden from body

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,7 +3,6 @@
 
 html, body {
    height: 100%;
-   overflow: hidden;
 }
 * {
    font-family: 'Dosis', sans-serif;


### PR DESCRIPTION
Removes overflow hidden from body element as it breaks mobile styling - I added this without realizing the implications on mobile.